### PR TITLE
Use conditional schemas for domain types to improve error messsages

### DIFF
--- a/schemas/domain.json
+++ b/schemas/domain.json
@@ -9,7 +9,11 @@
         "axes" :
         {
             "type" : "object",
-            "description" : "Set of Axis objects, keyed by axis identifier"
+            "description" : "Set of Axis objects, keyed by axis identifier",
+            "patternProperties" :
+            {
+                ".+" : { "$ref" : "/schemas/anyAxis" }
+            }
         },
         "referencing" :
         {
@@ -18,59 +22,55 @@
         }
     },
     "required" : [ "type", "axes" ],
-    "oneOf" :
-    [
+    "dependentSchemas":
+    {
+        "domainType":
         {
-            "description" : "Grid domain: x and y are required, z and t optional",
-            "properties" :
-            { 
-                "domainType" : { "const" : "Grid" },
-                "axes" :
+            "allOf":
+            [
                 {
-                    "properties" :
+                    "if": { "properties" : { "domainType" : { "const" : "Grid" } } },
+                    "then":
                     {
-                        "x" : { "$ref" : "/schemas/numericAxis" },
-                        "y" : { "$ref" : "/schemas/numericAxis" },
-                        "z" : { "$ref" : "/schemas/numericAxis" },
-                        "t" : { "$ref" : "/schemas/stringAxis" }
-                    },
-                    "required" : [ "x", "y" ],
-                    "additionalProperties" : false
-                }
-            },
-            "required" : [ "domainType" ]
-        },
-        {
-            "description" : "Trajectory domain: mandatory composite axis and optional z axis",
-            "properties" :
-            { 
-                "domainType" : { "const" : "Trajectory" },
-                "axes" :
+                        "description" : "Grid domain: x and y are required, z and t optional",
+                        "properties" :
+                        { 
+                            "axes" :
+                            {
+                                "properties" :
+                                {
+                                    "x" : { "$ref" : "/schemas/numericAxis" },
+                                    "y" : { "$ref" : "/schemas/numericAxis" },
+                                    "z" : { "$ref" : "/schemas/numericAxis" },
+                                    "t" : { "$ref" : "/schemas/stringAxis" }
+                                },
+                                "required" : [ "x", "y" ],
+                                "additionalProperties" : false
+                            }
+                        }
+                    }
+                },
                 {
-                    "properties" :
+                    "if": { "properties" : { "domainType" : { "const" : "Trajectory" } } },
+                    "then":
                     {
-                        "composite" : { "$ref" : "/schemas/tupleAxis" },
-                        "z" : { "$ref" : "/schemas/numericAxis" }
-                    },
-                    "required" : [ "composite" ],
-                    "additionalProperties" : false
-                }
-            },
-            "required" : [ "domainType" ]
-        },
-        {
-            "description" : "Default case: domainType omitted, no restrictions on axes",
-            "properties" :
-            {
-                "axes" :
-                {
-                    "patternProperties" :
-                    {
-                        ".+" : { "$ref" : "/schemas/anyAxis" }
+                        "description" : "Trajectory domain: mandatory composite axis and optional z axis",
+                        "properties" :
+                        { 
+                            "axes" :
+                            {
+                                "properties" :
+                                {
+                                    "composite" : { "$ref" : "/schemas/tupleAxis" },
+                                    "z" : { "$ref" : "/schemas/numericAxis" }
+                                },
+                                "required" : [ "composite" ],
+                                "additionalProperties" : false
+                            }
+                        }
                     }
                 }
-            },
-            "not" : { "required" : [ "domainType" ] }
+            ]
         }
-    ]
+    }
 }

--- a/test/test_domain.py
+++ b/test/test_domain.py
@@ -90,6 +90,14 @@ def test_valid_anonymous_domain():
     VALIDATOR.validate(domain)
 
 
+def test_valid_custom_domain():
+    ''' Tests a domain with a custom domainType (valid, but not recommended) '''
+
+    domain = get_sample_trajectory_domain()
+    domain["domainType"] = "https://foo/custom"
+    VALIDATOR.validate(domain)
+
+
 def test_missing_type():
     ''' Invalid: Grid domain with missing "type" '''
 


### PR DESCRIPTION
This makes a schema change for domain types using a combination of `dependentSchemas` and `if/then`. The errors are massively better and I think there's only minor overhead in writing the schema. Once https://github.com/json-schema-org/json-schema-spec/issues/1082 is a thing we can move to that which adds more syntax sugar for this case.

Before:
```
E           jsonschema.exceptions.ValidationError: {'type': 'Domain', 'domainType': 'Grid', 'axes': {'y': {'values': [1, 2]}, 't': {'values': ['2008-01-01T04:00:00Z', '2008-01-01T05:00:00Z']}}, 'referencing': [{'coordinates': ['t'], 'system': {'type': 'TemporalRS', 'calendar': 'Gregorian'}}, {'coordinates': ['x', 'y'], 'system': {'type': 'GeographicCRS', 'id': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'}}]} is not valid under any of the given schemas
E
E           Failed validating 'oneOf' in schema:
E               {'$id': '/schemas/domain',
E                'description': 'A Domain, which defines a set of positions and their '  
E                               'extent in one or more referencing systems',
E                'oneOf': [{'description': 'Grid domain: x and y are required, z and t ' 
E                                          'optional',
E                           'properties': {'axes': {'additionalProperties': False,       
E                                                   'properties': {'t': {'$ref': '/schemas/stringAxis'},
E                                                                  'x': {'$ref': '/schemas/numericAxis'},
E                                                                  'y': {'$ref': '/schemas/numericAxis'},
E                                                                  'z': {'$ref': '/schemas/numericAxis'}},
E                                                   'required': ['x', 'y']},
E                                          'domainType': {'const': 'Grid'}},
E                           'required': ['domainType']},
E                          {'description': 'Trajectory domain: mandatory composite '     
E                                          'axis and optional z axis',
E                           'properties': {'axes': {'additionalProperties': False,       
E                                                   'properties': {'composite': {'$ref': 
'/schemas/tupleAxis'},
E                                                                  'z': {'$ref': '/schemas/numericAxis'}},
E                                                   'required': ['composite']},
E                                          'domainType': {'const': 'Trajectory'}},       
E                           'required': ['domainType']},
E                          {'description': 'Default case: domainType omitted, no '       
E                                          'restrictions on axes',
E                           'not': {'required': ['domainType']},
E                           'properties': {'axes': {'patternProperties': {'.+': {'$ref': 
'/schemas/anyAxis'}}}}}],
E                'properties': {'axes': {'description': 'Set of Axis objects, keyed by ' 
E                                                       'axis identifier',
E                                        'type': 'object'},
E                               'domainType': {'type': 'string'},
E                               'referencing': {'items': {'$ref': '/schemas/referenceSystemConnection'},
E                                               'type': 'array'},
E                               'type': {'const': 'Domain'}},
E                'required': ['type', 'axes'],
E                'type': 'object'}
E
E           On instance:
E               {'axes': {'t': {'values': ['2008-01-01T04:00:00Z',
E                                          '2008-01-01T05:00:00Z']},
E                         'y': {'values': [1, 2]}},
E                'domainType': 'Grid',
E                'referencing': [{'coordinates': ['t'],
E                                 'system': {'calendar': 'Gregorian',
E                                            'type': 'TemporalRS'}},
E                                {'coordinates': ['x', 'y'],
E                                 'system': {'id': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
E                                            'type': 'GeographicCRS'}}],
E                'type': 'Domain'}
```

After:
```
E           jsonschema.exceptions.ValidationError: 'x' is a required property
E
E           Failed validating 'required' in schema['dependentSchemas']['domainType']['allOf'][0]['then']['properties']['axes']:
E               {'additionalProperties': False,
E                'properties': {'t': {'$ref': '/schemas/stringAxis'},
E                               'x': {'$ref': '/schemas/numericAxis'},
E                               'y': {'$ref': '/schemas/numericAxis'},
E                               'z': {'$ref': '/schemas/numericAxis'}},
E                'required': ['x', 'y']}
E
E           On instance['axes']:
E               {'t': {'values': ['2008-01-01T04:00:00Z']},
E                'y': {'values': [1]},
E                'z': {'values': [1, 2, 3]}}
```