### PR TITLE
Test wrong composite "coordinates"

### DIFF
--- a/schemas/domainBase.json
+++ b/schemas/domainBase.json
@@ -327,7 +327,8 @@
                                                     {
                                                         "$comment" : "There can only be one polygon in the axis",
                                                         "maxItems" : 1
-                                                    }
+                                                    },
+                                                    "coordinates": { "const" : ["x", "y"] }
                                                 }
                                             }
                                         ]
@@ -364,7 +365,8 @@
                                                     {
                                                         "$comment" : "There can only be one polygon in the axis",
                                                         "maxItems" : 1
-                                                    }
+                                                    },
+                                                    "coordinates": { "const" : ["x", "y"] }
                                                 }
                                             }
                                         ]
@@ -389,7 +391,19 @@
                             {
                                 "properties" :
                                 {
-                                    "composite" : { "$ref": "/schemas/polygonValuesAxis" },
+                                    "composite" :
+                                    { 
+                                        "allOf" :
+                                        [
+                                            { "$ref": "/schemas/polygonValuesAxis" },
+                                            {
+                                                "properties" :
+                                                {
+                                                    "coordinates": { "const" : ["x", "y"] }
+                                                }
+                                            }
+                                        ]
+                                    },
                                     "z" : { "$ref" : "/schemas/numericSingleValueAxis" },
                                     "t" : { "$ref" : "/schemas/stringSingleValueAxis" }
                                 },
@@ -410,7 +424,19 @@
                             {
                                 "properties" :
                                 {
-                                    "composite" : { "$ref": "/schemas/polygonValuesAxis" },
+                                    "composite" :
+                                    {
+                                        "allOf" :
+                                        [
+                                            { "$ref": "/schemas/polygonValuesAxis" },
+                                            {
+                                                "properties" :
+                                                {
+                                                    "coordinates": { "const" : ["x", "y"] }
+                                                }
+                                            }
+                                        ]
+                                    },
                                     "z" : { "$ref" : "/schemas/numericSingleValueAxis" },
                                     "t" : { "$ref" : "/schemas/stringValuesAxis" }
                                 },

--- a/schemas/domainBase.json
+++ b/schemas/domainBase.json
@@ -183,6 +183,14 @@
                                                             "minItems" : 2,
                                                             "maxItems" : 3
                                                         }
+                                                    },
+                                                    "coordinates": 
+                                                    {
+                                                        "enum":
+                                                        [
+                                                            ["x", "y", "z"],
+                                                            ["x", "y"]
+                                                        ]
                                                     }
                                                 }
                                             }

--- a/schemas/domainBase.json
+++ b/schemas/domainBase.json
@@ -77,6 +77,14 @@
                                                             "minItems" : 3,
                                                             "maxItems" : 4
                                                         }
+                                                    },
+                                                    "coordinates": 
+                                                    {
+                                                        "enum":
+                                                        [
+                                                            ["t", "x", "y", "z"],
+                                                            ["t", "x", "y"]
+                                                        ]
                                                     }
                                                 }
                                             }
@@ -231,6 +239,14 @@
                                                             "minItems" : 2,
                                                             "maxItems" : 3
                                                         }
+                                                    },
+                                                    "coordinates": 
+                                                    {
+                                                        "enum":
+                                                        [
+                                                            ["x", "y", "z"],
+                                                            ["x", "y"]
+                                                        ]
                                                     }
                                                 }
                                             }
@@ -271,6 +287,10 @@
                                                             "minItems" : 3,
                                                             "maxItems" : 3
                                                         }
+                                                    },
+                                                    "coordinates": 
+                                                    {
+                                                        "const": ["t", "x", "y"]
                                                     }
                                                 }
                                             }

--- a/schemas/polygonValuesAxis.json
+++ b/schemas/polygonValuesAxis.json
@@ -28,7 +28,7 @@
                         "minItems" : 1
                     }
                 },
-                "coordinates": { "const" : ["x", "y"] }
+                "coordinates": { }
             },
             "required" : [ "dataType", "values", "coordinates" ],
             "additionalProperties" : false

--- a/schemas/polygonValuesAxis.json
+++ b/schemas/polygonValuesAxis.json
@@ -28,7 +28,7 @@
                         "minItems" : 1
                     }
                 },
-                "coordinates": { }
+                "coordinates": { "const" : ["x", "y"] }
             },
             "required" : [ "dataType", "values", "coordinates" ],
             "additionalProperties" : false

--- a/test/domain_types/test_multipoint.py
+++ b/test/domain_types/test_multipoint.py
@@ -71,6 +71,14 @@ def test_wrong_composite_axis_coordinates(validator, multipoint_domain):
         validator.validate(multipoint_domain)
 
 
+def test_wrong_composite_axis_coordinates2(validator, multipoint_domain):
+    ''' Invalid: MultiPoint domain with invalid coordinates '''
+
+    multipoint_domain["axes"]["composite"]["coordinates"] = ["z", "y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(multipoint_domain)
+
+
 def test_extra_axis(validator, multipoint_domain):
     ''' Invalid: MultiPoint domain with unrecognised extra axis '''
 
@@ -94,7 +102,3 @@ def test_empty_t_axis(validator, multipoint_domain):
     multipoint_domain["axes"]["t"] = { "values" : [] }
     with pytest.raises(ValidationError):
         validator.validate(multipoint_domain)
-
-
-# TODO test coordinate identifiers of 'composite' axis
-#      to be "x","y","z" or "x","y"

--- a/test/domain_types/test_multipoint.py
+++ b/test/domain_types/test_multipoint.py
@@ -63,6 +63,14 @@ def test_wrong_composite_axis_type(validator, multipoint_domain):
         validator.validate(multipoint_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, multipoint_domain):
+    ''' Invalid: MultiPoint domain with invalid coordinates '''
+
+    multipoint_domain["axes"]["composite"]["coordinates"] = ["y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(multipoint_domain)
+
+
 def test_extra_axis(validator, multipoint_domain):
     ''' Invalid: MultiPoint domain with unrecognised extra axis '''
 

--- a/test/domain_types/test_multipointseries.py
+++ b/test/domain_types/test_multipointseries.py
@@ -55,6 +55,22 @@ def test_wrong_composite_axis_type(validator, multipointseries_domain):
         validator.validate(multipointseries_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, multipointseries_domain):
+    ''' Invalid: MultiPointSeries domain with invalid coordinates '''
+
+    multipointseries_domain["axes"]["composite"]["coordinates"] = ["y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(multipointseries_domain)
+
+
+def test_wrong_composite_axis_coordinates2(validator, multipointseries_domain):
+    ''' Invalid: MultiPointSeries domain with invalid coordinates '''
+
+    multipointseries_domain["axes"]["composite"]["coordinates"] = ["z", "y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(multipointseries_domain)
+
+
 def test_composite_axis_with_1_value(validator, multipointseries_domain):
     ''' Invalid: MultiPointSeries domain with composite axis with tuples of length 1 '''
 
@@ -88,6 +104,4 @@ def test_extra_axis(validator, multipointseries_domain):
         validator.validate(multipointseries_domain)
 
 
-# TODO test coordinate identifiers of 'composite' axis
-#      to be "x","y","z" or "x","y"
 # TODO test that all values in 'composite' axis are valid and consistent tuples

--- a/test/domain_types/test_multipolygon.py
+++ b/test/domain_types/test_multipolygon.py
@@ -29,6 +29,14 @@ def test_empty_composite_axis(validator, multipolygon_domain):
         validator.validate(multipolygon_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, multipolygon_domain):
+    ''' Invalid: MultiPolygon domain with invalid coordinates '''
+
+    multipolygon_domain["axes"]["composite"]["coordinates"] = ["y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(multipolygon_domain)
+
+
 def test_wrong_composite_axis_type(validator, multipolygon_domain):
     ''' Invalid: MultiPolygon domain with primitive instead of polygon axis '''
 
@@ -94,6 +102,3 @@ def test_multivalued_t_axis(validator, multipolygon_domain):
     multipolygon_domain["axes"]["t"] = { "values" : ["2008-01-01T04:00:00Z", "2008-01-01T05:00:00Z"] }
     with pytest.raises(ValidationError):
         validator.validate(multipolygon_domain)
-
-
-# TODO check coordinates are "x","y", in that order

--- a/test/domain_types/test_multipolygonseries.py
+++ b/test/domain_types/test_multipolygonseries.py
@@ -47,6 +47,14 @@ def test_wrong_composite_axis_type2(validator, multipolygonseries_domain):
         validator.validate(multipolygonseries_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, multipolygonseries_domain):
+    ''' Invalid: MultiPolygonSeries domain with invalid coordinates '''
+
+    multipolygonseries_domain["axes"]["composite"]["coordinates"] = ["y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(multipolygonseries_domain)
+
+
 def test_wrong_data_type(validator, multipolygonseries_domain):
     ''' Invalid: MultiPolygonSeries domain with wrong data type '''
 
@@ -86,6 +94,3 @@ def test_empty_t_axis(validator, multipolygonseries_domain):
     multipolygonseries_domain["axes"]["t"] = { "values" : [] }
     with pytest.raises(ValidationError):
         validator.validate(multipolygonseries_domain)
-
-
-# TODO check coordinates are "x","y"

--- a/test/domain_types/test_polygon.py
+++ b/test/domain_types/test_polygon.py
@@ -58,6 +58,14 @@ def test_composite_axis_with_2_values(validator, polygon_domain):
         validator.validate(polygon_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, polygon_domain):
+    ''' Invalid: Polygon domain with invalid coordinates '''
+
+    polygon_domain["axes"]["composite"]["coordinates"] = ["y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(polygon_domain)
+
+
 def test_wrong_data_type(validator, polygon_domain):
     ''' Invalid: Polygon domain with wrong data type '''
 
@@ -105,6 +113,3 @@ def test_multivalued_t_axis(validator, polygon_domain):
     polygon_domain["axes"]["t"] = { "values" : ["2008-01-01T04:00:00Z", "2008-01-01T05:00:00Z"] }
     with pytest.raises(ValidationError):
         validator.validate(polygon_domain)
-
-
-# TODO check coordinates are "x","y"

--- a/test/domain_types/test_polygonseries.py
+++ b/test/domain_types/test_polygonseries.py
@@ -39,6 +39,14 @@ def test_wrong_composite_axis_type(validator, polygonseries_domain):
         validator.validate(polygonseries_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, polygonseries_domain):
+    ''' Invalid: PolygonSeries domain with invalid coordinates '''
+
+    polygonseries_domain["axes"]["composite"]["coordinates"] = ["y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(polygonseries_domain)
+
+
 def test_wrong_composite_axis_type2(validator, polygonseries_domain):
     ''' Invalid: PolygonSeries domain with tuple instead of polygon axis (invalid polygons) '''
 
@@ -97,6 +105,3 @@ def test_empty_t_axis(validator, polygonseries_domain):
     polygonseries_domain["axes"]["t"] = { "values" : [] }
     with pytest.raises(ValidationError):
         validator.validate(polygonseries_domain)
-
-
-# TODO check coordinates are "x","y"

--- a/test/domain_types/test_section.py
+++ b/test/domain_types/test_section.py
@@ -65,7 +65,6 @@ def test_wrong_composite_axis_coordinates(validator, section_domain):
     ''' Invalid: Section domain with invalid coordinates '''
 
     section_domain["axes"]["composite"]["coordinates"] = ["t", "y", "x"]
-    print(section_domain)
     with pytest.raises(ValidationError):
         validator.validate(section_domain)
 

--- a/test/domain_types/test_section.py
+++ b/test/domain_types/test_section.py
@@ -56,9 +56,16 @@ def test_composite_axis_with_4_values(validator, section_domain):
 def test_wrong_composite_axis_type(validator, section_domain):
     ''' Invalid: Section domain with primitive instead of tuple axis '''
 
-    section_domain["axes"]["composite"] = {
-        "values": [1, 2, 3]
-    }
+    section_domain["axes"]["composite"]["values"] = [1, 2, 3]
+    with pytest.raises(ValidationError):
+        validator.validate(section_domain)
+
+
+def test_wrong_composite_axis_coordinates(validator, section_domain):
+    ''' Invalid: Section domain with invalid coordinates '''
+
+    section_domain["axes"]["composite"]["coordinates"] = ["t", "y", "x"]
+    print(section_domain)
     with pytest.raises(ValidationError):
         validator.validate(section_domain)
 
@@ -86,7 +93,3 @@ def test_empty_z_axis(validator, section_domain):
     section_domain["axes"]["z"] = { "values" : [] }
     with pytest.raises(ValidationError):
         validator.validate(section_domain)
-
-
-# TODO test coordinate identifiers of 'composite' axis
-#      to be "t","x","y" (can these be in another order?)

--- a/test/domain_types/test_trajectory.py
+++ b/test/domain_types/test_trajectory.py
@@ -39,6 +39,22 @@ def test_wrong_composite_axis_type(validator, trajectory_domain):
         validator.validate(trajectory_domain)
 
 
+def test_wrong_composite_axis_coordinates(validator, trajectory_domain):
+    ''' Invalid: Trajectory domain with invalid coordinates '''
+
+    trajectory_domain["axes"]["composite"]["coordinates"] = ["t", "y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(trajectory_domain)
+
+
+def test_wrong_composite_axis_coordinates2(validator, trajectory_domain):
+    ''' Invalid: Trajectory domain with invalid coordinates '''
+
+    trajectory_domain["axes"]["composite"]["coordinates"] = ["t", "z", "y", "x"]
+    with pytest.raises(ValidationError):
+        validator.validate(trajectory_domain)
+
+
 def test_composite_axis_with_2_values(validator, trajectory_domain):
     ''' Invalid: Trajectory domain with composite axis with tuples of length 2 '''
 
@@ -88,6 +104,4 @@ def test_multivalued_z_axis(validator, trajectory_domain):
         validator.validate(trajectory_domain)
 
 
-# TODO test coordinate identifiers of 'composite' axis
-#      to be "t","x","y","z" or "t","x","y"
 # TODO test there cannot be both 'z' in 'composite' and a 'z' axis


### PR DESCRIPTION
(Work in progress)
This tests that the "coordinates" of common domain types of composite axes are as expected.

@jonblower I won't have time to finish this right now but it should be straight-forward. If you can, please add the other cases and tests. I think this is the last thing that makes sense to add in the schema before declaring a first version.