### PR TITLE
Check "calendar" value

### DIFF
--- a/schemas/referenceSystem.json
+++ b/schemas/referenceSystem.json
@@ -15,7 +15,15 @@
                 "description" : "Temporal reference system",
                 "properties" :
                 {
-                    "calendar" : { "type" : "string" },
+                    "calendar" : 
+                    {
+                        "type" : "string",
+                        "oneOf" :
+                        [
+                            { "const" : "Gregorian" },
+                            { "pattern": "^https?://" }
+                        ]
+                    },
                     "timeScale" : { "type" : "string" }
                 },
                 "required" : [ "calendar" ]

--- a/test/test_referenceSystem.py
+++ b/test/test_referenceSystem.py
@@ -1,7 +1,5 @@
 # Pytests to test the referenceSystem.json schema file
 
-# TODO: test that "calendar" is "Gregorian" or a URI
-
 import pytest
 from jsonschema.exceptions import ValidationError
 
@@ -48,6 +46,26 @@ def test_minimal_temporal_rs(validator):
     validator.validate(crs)
 
 
+def test_http_uri_calendar(validator):
+    ''' Tests a TemporalRS with an HTTP URI calendar '''
+
+    crs = {
+        "type" : "TemporalRS",
+        "calendar" : "http://some/calendar"
+    }
+    validator.validate(crs)
+
+
+def test_https_uri_calendar(validator):
+    ''' Tests a TemporalRS with an HTTPS URI calendar '''
+
+    crs = {
+        "type" : "TemporalRS",
+        "calendar" : "https://some/calendar"
+    }
+    validator.validate(crs)
+
+
 def test_identifier_rs(validator):
     ''' Tests an example of an IdentifierRS '''
 
@@ -85,6 +103,17 @@ def test_missing_calendar(validator):
     ''' Tests a TemporalRS with a missing calendar '''
 
     crs = { "type" : "TemporalRS" }
+    with pytest.raises(ValidationError):
+        validator.validate(crs)
+
+
+def test_unknown_non_uri_calendar(validator):
+    ''' Tests a TemporalRS with a missing calendar '''
+
+    crs = {
+        "type" : "TemporalRS",
+        "calendar" : "Julian"
+    }
     with pytest.raises(ValidationError):
         validator.validate(crs)
 


### PR DESCRIPTION
This PR extends the schema for TemporalRS to check that `"calendar"` is either `Gregorian` or a URI. For simplicity of the regex pattern I restricted it to http/https URIs which is stricter than the spec which allows arbitrary URIs including URNs. Since OGC moved away from URNs I don't think this is a problem though. 