### PR TITLE
Add support for urls/network documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ N.B. Make sure to install requirements via `pip`, not `conda` (at the time of wr
 python -m tools.validator my.covjson
 ```
 
+To test a server/api response, specify that the file source is an URL using the `--source` flag. Its default value is `file`
+
+```sh
+python -m tools.validator --source=url "https://mydomain.com/collections/cov"
+```
+
 ## Testing the validator
 ```sh
 python -m pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema
 exhaust
 pytest
+requests

--- a/tools/validator.py
+++ b/tools/validator.py
@@ -46,12 +46,22 @@ def create_custom_validator(schema_id, schema_store=None):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
+    parser.add_argument('--source', type=str, choices=['url', 'file'], default='file', help='Source of the CoverageJSON document')
     parser.add_argument('covjson_path', type=str,
                         help='Path to CoverageJSON document')
+    
     args = parser.parse_args()
 
-    with open(args.covjson_path, encoding="utf-8") as f:
-        obj = json.load(f)
+    if args.source == 'url':
+        import requests
+        # Get the file from the URL
+        response = requests.get(args.covjson_path)
+        response.raise_for_status()  # Raise an exception if the request was unsuccessful
+        obj = response.json()
+    else:
+        # Assume the covjson_path is a local file
+        with open(args.covjson_path, encoding="utf-8") as f:
+            obj = json.load(f)
 
     validator = create_custom_validator("/schemas/coveragejson")
     validator.validate(obj)


### PR DESCRIPTION
Enable validation of coverageJSON from an API. Especially for those where file downloads require manual intervation