### PR TITLE
Removed use of $def, fixing broken tests

### DIFF
--- a/schemas/referenceSystem.json
+++ b/schemas/referenceSystem.json
@@ -39,32 +39,18 @@
                     "id" : { "type" : "string" },
                     "label" : { "$ref" : "/schemas/i18n" },
                     "description" : { "$ref" : "/schemas/i18n" },
-                    "targetConcept" : { "$ref" : "#/$defs/targetConcept" },
+                    "targetConcept" : { "$ref" : "/schemas/targetConcept" },
                     "identifiers" :
                     {
                         "type" : "object",
                         "patternProperties" :
                         {
-                            ".+" : { "$ref" : "#/$defs/targetConcept" }
+                            ".+" : { "$ref" : "/schemas/targetConcept" }
                         }
                     }
                 },
                 "required" : [ "targetConcept" ]
             }
         }
-    ],
-    "$defs" :
-    {
-        "targetConcept" :
-        {
-            "type" : "object",
-            "properties" :
-            {
-                "id" : { "type" : "string" },
-                "label" : { "$ref" : "/schemas/i18n" },
-                "description" : { "$ref" : "/schemas/i18n" }
-            },
-            "required" : [ "label" ]
-        }
-    }
+    ]
 }

--- a/schemas/targetConcept.json
+++ b/schemas/targetConcept.json
@@ -1,0 +1,11 @@
+{
+    "$id": "/schemas/targetConcept",
+    "description" : "A concept in an identifier-based reference system",
+    "properties" :
+    {
+        "id" : { "type" : "string" },
+        "label" : { "$ref" : "/schemas/i18n" },
+        "description" : { "$ref" : "/schemas/i18n" }
+    },
+    "required" : [ "label" ]
+}


### PR DESCRIPTION
Tests with `referenceSystem.json` were failing. This removes the use of the $def keyword, factoring out `targetConcept` into a new schema file. Tests now pass.