### PR TITLE
Runtime validation cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ N.B. Make sure to install requirements via `pip`, not `conda` (at the time of wr
 python -m tools.validator my.covjson
 ```
 
-To test a server/api response, specify that the file source is an URL using the `--source` flag. Its default value is `file`
+To test a server/api response, pass an absolute URL string that includes the http scheme
 
 ```sh
-python -m tools.validator --source=url "https://mydomain.com/collections/cov"
+python -m tools.validator "https://mydomain.com/collections/cov"
 ```
 
 ## Testing the validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jsonschema
 exhaust
 pytest
 requests
+uritemplate

--- a/test/test_coverage.py
+++ b/test/test_coverage.py
@@ -2,6 +2,7 @@
 
 import pytest
 from jsonschema.exceptions import ValidationError
+from tools.validator import validate_coverage
 
 pytestmark = pytest.mark.schema("/schemas/coverage")
 
@@ -209,3 +210,14 @@ def test_incorrect_alternate_ranges(validator):
 # TODO test that "shape" of (Tiled)NdArray "ranges" matches "axes" of "domain"
 # TODO test that "values" of (Tiled)NdArray "ranges" matches the parameter's
 #      "categoryEncoding", if existing
+
+
+def test_ranges_reference_existing_param():
+    ''' Invalid: All ranges in parameters reference existing parameter '''
+
+    cov=get_sample_coverage()
+    cov["ranges"]["UnlistedParam"]="http://example.com/data.covjson"
+    cov["ranges"]["YetAnotherUnlistedParam"]="http://example.com/data1.covjson"
+    
+    with pytest.raises(ValidationError):
+        validate_coverage(cov)

--- a/test/test_coverageCollection.py
+++ b/test/test_coverageCollection.py
@@ -2,6 +2,8 @@
 
 import pytest
 from jsonschema.exceptions import ValidationError
+from tools.validator import validate_coverage_collection
+from .test_coverage import get_sample_coverage
 
 pytestmark = pytest.mark.schema("/schemas/coverageCollection")
 
@@ -232,4 +234,24 @@ def test_incorrect_referencing_type(validator):
         validator.validate(collection)
 
 
-# TODO test that all coverage ranges reference a parameter in scope
+def test_with_defined_domainType():
+    ''' Invalid: Collection with predefined domainType throws on other domainTypes '''
+    collection=get_sample_coverage_collection()
+    cov=get_sample_coverage()
+    
+    collection["coverages"].append(cov)
+    with pytest.raises(ValidationError):
+        validate_coverage_collection(collection)
+
+def test_ranges_reference_existing_param():
+    ''' Invalid: All ranges in parameters reference existing parameter '''
+    collection=get_sample_coverage_collection()
+    cov=get_sample_coverage()
+    cov["ranges"]["UnlistedParam"]="http://example.com/data.covjson"
+    collection["coverages"].append(cov)
+    with pytest.raises(ValidationError):
+        validate_coverage_collection(collection)
+
+def test_collection():
+    collection=get_sample_coverage_collection()
+    validate_coverage_collection(collection)

--- a/test/test_coveragejson.py
+++ b/test/test_coveragejson.py
@@ -7,6 +7,7 @@ from .test_ndArray import get_example_ndarray
 from .test_tiledNdArray import get_example_tiled_ndarray
 from .test_coverage import get_sample_coverage
 from .test_coverageCollection import get_sample_coverage_collection
+from tools.validator import runtime_validator
 
 pytestmark = pytest.mark.schema("/schemas/coveragejson")
 
@@ -65,3 +66,31 @@ def test_misspelled_type(validator, get_domain):
     domain["type"] = "Doman"
     with pytest.raises(ValidationError):
         validator.validate(domain)
+
+def test_ndarray():
+    ''' Valid: NdArray is valid according to custom validator '''
+    ndarray=get_example_ndarray()
+    runtime_validator(ndarray)
+    
+def test_tiledNdArray():
+    ''' Valid: TiledNdArray is valid according to custom validator '''
+    tiled_ndarray=get_example_tiled_ndarray()
+    runtime_validator(tiled_ndarray)
+
+def test_coverage():
+    ''' Valid: Coverage is valid according to custom validator '''
+    coverage=get_sample_coverage()
+    runtime_validator(coverage)
+
+def test_coverageCollection():
+    ''' Valid: CoverageCollection is valid according to custom validator '''
+    collection=get_sample_coverage_collection()
+    runtime_validator(collection)
+    
+def test_invalid_document():
+    ''' Invalid: Document is not valid CoverageJSON '''
+    coverage=get_sample_coverage()
+    coverage["type"]="NotACoverage"
+    
+    with pytest.raises(ValidationError):
+        runtime_validator(coverage)

--- a/test/test_ndArray.py
+++ b/test/test_ndArray.py
@@ -2,6 +2,7 @@
 
 import pytest
 from jsonschema.exceptions import ValidationError
+from tools.validator import validate_range
 
 pytestmark = pytest.mark.schema("/schemas/ndArray")
 
@@ -168,3 +169,26 @@ def test_non_0d_with_missing_shape_and_axis_names(validator):
 # TODO test that "values" has the same length as mul("shape")
 # NOTE: the spec doesn't specify this currently, which is a bug
 # TODO test that "shape" and "axisNames" have the same length if non-empty
+
+def test_valid_ndarray():
+    ''' Valid: Sanity check for ndarray '''
+    ndarray=get_example_ndarray()
+    validate_range(ndarray)
+
+def test_values_shape_length():
+    ''' Invalid: values has same length as product(shape) '''
+    ndarray=get_example_ndarray()
+    ndarray["shape"]=[4,2,1]
+    
+    with pytest.raises(ValidationError):
+        validate_range(ndarray)
+
+def test_shape_axisNames_length():
+    ''' Invalid: If non-empty, shape and axisNames have same length '''
+
+    # TODO There are several validations that can raise an Exception before even checking for this
+    ndarray=get_example_ndarray()
+    ndarray["axisNames"]=["x","y","t"]
+    
+    with pytest.raises(ValidationError):
+        validate_range(ndarray)

--- a/test/test_parameter.py
+++ b/test/test_parameter.py
@@ -5,7 +5,7 @@
 
 import pytest
 from jsonschema.exceptions import ValidationError
-
+from tools.validator import validate_parameter
 pytestmark = pytest.mark.schema("/schemas/parameter")
 
 
@@ -171,3 +171,62 @@ def test_nonunique_category_encoding(validator):
     }
     with pytest.raises(ValidationError):
         validator.validate(param)
+
+def test_nonunique_category_encoding_values():
+    ''' Invalid: all integers specified by the categoryEncoding must be unique '''
+    param = {
+        "type" : "Parameter",
+        "observedProperty" : {
+            "label" : { "en" : "Land Cover" },
+            "categories": [{
+                "id": "http://example.com/land_cover/categories/grass",
+                "label": { "en" : "Grass" },
+            }, {
+                "id": "http://example.com/land_cover/categories/forest",
+                "label": { "en" : "Forest" }
+            }]
+        },
+        "categoryEncoding": {
+            "http://example.com/land_cover/categories/grass": 1,
+            "http://example.com/land_cover/categories/forest": [1,2]
+        }
+    }
+    
+    with pytest.raises(ValidationError):
+        validate_parameter(param)
+        
+def test_category_encoding_without_category_object():
+    ''' Invalid: All categoryEncoding keys must have an associated category object in observedProperty '''
+    param = {
+        "type" : "Parameter",
+        "observedProperty" : {
+            "label" : { "en" : "Land Cover" },
+            "categories": [{
+                "id": "http://example.com/land_cover/categories/grass",
+                "label": { "en" : "Grass" },
+            }]
+        },
+        "categoryEncoding": {
+            "http://example.com/land_cover/categories/grass": 1,
+            "http://example.com/land_cover/categories/forest": [1,2]
+        }
+    }
+    
+    with pytest.raises(ValidationError):
+        validate_parameter(param)
+
+def test_category_encoding_without_categories():
+    ''' Invalid: categories must be defined if categoryEncoding is present '''
+    param = {
+        "type" : "Parameter",
+        "observedProperty" : {
+            "label" : { "en" : "Land Cover" },
+        },
+        "categoryEncoding": {
+            "http://example.com/land_cover/categories/grass": 1,
+            "http://example.com/land_cover/categories/forest": [2,3]
+        }
+    }
+    
+    with pytest.raises(ValidationError):
+        validate_parameter(param)

--- a/test/test_parameterGroup.py
+++ b/test/test_parameterGroup.py
@@ -2,6 +2,7 @@
 
 import pytest
 from jsonschema.exceptions import ValidationError
+from tools.validator import validate_parameter_group
 
 pytestmark = pytest.mark.schema("/schemas/parameterGroup")
 
@@ -125,3 +126,11 @@ def test_members_with_incorrect_item_type(validator):
 
 # TODO the spec says observedProperty is the same as for Parameter
 #      but it wouldn't make sense to have "categories" in there
+
+
+def test_members_includes_invalid():
+    "Invalid: parameterGroup with 'members' including non-valid parameter keys"
+    group=get_example_parameter_group()
+    group["members"].append(["YARN"])
+    with pytest.raises(ValidationError):
+        validate_parameter_group(group,["SST_mean", "SST_stddev"])

--- a/test/test_playground_coverages.py
+++ b/test/test_playground_coverages.py
@@ -8,9 +8,10 @@ from tools.validator import runtime_validator
 
 pytestmark = pytest.mark.schema("/schemas/coveragejson")
 
-def test_all_playground_coverages(validator):
-
-    # Recursively traverse the test_data/playground directory
+def load_all_coverages():
+    coverages=dict()
+    
+   # Recursively traverse the test_data/playground directory
     rootpath = os.path.join(os.path.dirname(__file__), "test_data", "playground")
     for subdir, dirs, files in os.walk(rootpath):
 
@@ -23,7 +24,15 @@ def test_all_playground_coverages(validator):
             # Load the JSON
             with open(fullpath) as f:
                 j = json.load(f)
+                coverages[file.split(".covjson")[0]]=j
+    return coverages
 
-            # Validate the JSON
-            validator.validate(j)
-            runtime_validator(j)
+coverages=load_all_coverages()
+              
+def test_all_playground_coverages(validator):
+    for id in coverages:
+        validator.validate(coverages[id])
+
+def test_using_runtime_validator():
+    for id in coverages:
+        runtime_validator(coverages[id])

--- a/test/test_playground_coverages.py
+++ b/test/test_playground_coverages.py
@@ -4,6 +4,7 @@ import os
 from jsonschema import ValidationError
 import pytest
 import json
+from tools import validator as v
 
 pytestmark = pytest.mark.schema("/schemas/coveragejson")
 
@@ -25,3 +26,6 @@ def test_all_playground_coverages(validator):
 
             # Validate the JSON
             validator.validate(j)
+            print(fullpath)
+            # TODO Over 400% test perfomance degradation
+            v.runtime_validator(j)

--- a/test/test_playground_coverages.py
+++ b/test/test_playground_coverages.py
@@ -4,7 +4,7 @@ import os
 from jsonschema import ValidationError
 import pytest
 import json
-from tools import validator as v
+from tools.validator import runtime_validator
 
 pytestmark = pytest.mark.schema("/schemas/coveragejson")
 
@@ -26,6 +26,4 @@ def test_all_playground_coverages(validator):
 
             # Validate the JSON
             validator.validate(j)
-            print(fullpath)
-            # TODO Over 400% test perfomance degradation
-            v.runtime_validator(j)
+            runtime_validator(j)

--- a/test/test_tiledNdArray.py
+++ b/test/test_tiledNdArray.py
@@ -2,6 +2,7 @@
 
 import pytest
 from jsonschema.exceptions import ValidationError
+from tools.validator import validate_range
 
 pytestmark = pytest.mark.schema("/schemas/tiledNdArray")
 
@@ -9,18 +10,18 @@ pytestmark = pytest.mark.schema("/schemas/tiledNdArray")
 def get_example_tiled_ndarray():
     return {
         "type" : "TiledNdArray",
-        "dataType": "float",
+        "dataType": "integer",
         "axisNames": ["t", "y", "x"],
         "shape": [2, 5, 10],
         "tileSets": [{
             "tileShape": [None, None, None],
-            "urlTemplate": "http://example.com/a/all.covjson"
+            "urlTemplate": "https://covjson.org/playground/coverages/grid-tiled/c/all.covjson"
         }, {
             "tileShape": [1, None, None],
-            "urlTemplate": "http://example.com/b/{t}.covjson"
+            "urlTemplate": "https://covjson.org/playground/coverages/grid-tiled/b/{t}.covjson"
         }, {
             "tileShape": [None, 2, 3],
-            "urlTemplate": "http://example.com/c/{y}-{x}.covjson"
+            "urlTemplate": "https://covjson.org/playground/coverages/grid-tiled/a/{y}-{x}.covjson"
         }]
     }
 
@@ -211,7 +212,35 @@ def test_incorrect_url_template_type(validator):
         validator.validate(tiled_ndarray)
 
 
-# TODO test that "shape" and "axisNames" have the same length
-# TODO test that "tileShape" has the same length as "shape"
 # TODO test that "urlTemplate" is a valid RFC 6570 Level 1 URI template
-# TODO test that "urlTemplate" contains the right '{}' variables
+
+def test_axisnames_shape_length_valid():
+    ''' Valid: shape and axisNames have same length '''
+    tiled_ndarray=get_example_tiled_ndarray()
+    validate_range(tiled_ndarray)
+    
+def test_axisnames_shape_length():
+    ''' Invalid: shape and axisNames have the same length '''
+    tiled_ndarray=get_example_tiled_ndarray()
+    tiled_ndarray["axisNames"]=tiled_ndarray["axisNames"][0:len(tiled_ndarray["axisNames"])-2]
+    
+    with pytest.raises(ValidationError):
+        validate_range(tiled_ndarray)
+
+def tile_shape_shape_length():
+    ''' Invalid: tileShape and shape have same length '''
+    
+    tiled_ndarray=get_example_tiled_ndarray()
+    tiled_ndarray["shape"]=tiled_ndarray["shape"][0:len(tiled_ndarray["shape"])-2]
+    
+    with pytest.raises(ValidationError):
+        validate_range(tiled_ndarray)
+        
+def urltemplate_contains_right_variables():
+    ''' Invalid: Validate that each urlTemplate only contains axisName variables '''
+    
+    tiled_ndarray=get_example_tiled_ndarray()
+    tiled_ndarray["tileSets"]=[{"urlTemplate":"https://covjson.org/playground/coverages/grid-tiled/c/{x}/all.covjson"}]
+    
+    with pytest.raises(ValidationError):
+        validate_range(tiled_ndarray)

--- a/tools/validator.py
+++ b/tools/validator.py
@@ -79,7 +79,7 @@ def axis_name_combinations(axis_data:Dict[str,int])->Tuple[List[str],List[int]]:
         permutations_per_length = [list(permutations(groups[l])) for l in sorted_lengths]
         
         # Generate all combinations via Cartesian product
-        for combo in product(*perms_per_length):
+        for combo in product(*permutations_per_length):
             # Flatten names and generate matching shape
             flat_names = [name for sub in combo for name in sub]
             flat_shape = [axis_data[name] for name in flat_names]

--- a/tools/validator.py
+++ b/tools/validator.py
@@ -100,8 +100,11 @@ def loadStringDocument(url:str)->Dict:
     
     res=requests.get(url)
     res.raise_for_status()
-    if res.headers.get("content-type") != "application/prs.coverage+json":
-        warn(f"Expected content-type header to be 'application/prs.coverage+json' but found {res.headers.get("content-type")}")
+    media_type=res.headers.get("content-type")
+    if media_type == "application/prs.coverage+json":
+        warn("content-type header 'application/prs.coverage+json' has been deprecated in favour of 'application/cov+json")
+    elif media_type != "application/cov+json":
+        warn(f"expected content-type header to be application/cov+json but got {media_type}")
     document=res.json()
     return document
 

--- a/tools/validator.py
+++ b/tools/validator.py
@@ -1,10 +1,18 @@
 # Creates a custom JSON schema validator with a reference resolver
 # that can resolve any reference in the /schemas directory
 
+import argparse
 import os
 import json
 import jsonschema
-
+import requests
+from typing import Dict,List
+from uritemplate import URITemplate
+from urllib.parse import urlparse
+import math
+from itertools import product,permutations
+from collections import defaultdict
+from warnings import warn
 
 def create_schema_store():
     ''' Creates a store that maps schema ids to schema documents '''
@@ -42,19 +50,206 @@ def create_custom_validator(schema_id, schema_store=None):
 
     return validator
 
+validator=create_custom_validator("/schemas/coveragejson")
+
+def custom_validator(schema:object):
+    "A  validator function to validate against runtime schemas"
+    return jsonschema.Draft202012Validator(schema)
+
+def axis_name_combinations(axisData:Dict[str,int])->List[List[str],List[int]]:
+    "Return all possible combinations of the expected shape and axisNames of the range\n"
+    "This is required for domains where multiple axes have the same lengths and so data can be arranged in multiple valid combinations"
+    
+    groups=defaultdict(list)
+    for axisName,length in axisData.items():
+        groups[length].append(axisName)
+    sortedLengths=sorted(groups.keys())
+    permutations_per_length=[list(permutations(groups[l])) for l in sortedLengths]
+    
+    axisShape=[]
+    for length in sortedLengths:
+        axisShape.extend([length]*len(groups[length]))
+        
+    axisNames=[]
+    for combo in product(*permutations_per_length):
+        axisNames.append([name for sub in combo for name in sub])
+    return [axisNames,axisShape]       
+
+def loadStringDocument(url:str)->Dict:
+    "Loads a URL CoverageJSON Document and validates the request and the json document"
+    custom_validator({"type":"string","format":"uri"}).validate(url)
+    
+    res=requests.get(url)
+    res.raise_for_status()
+    if res.headers.get("content-type") != "application/prs.coverage+json":
+        warn(f"Expected content-type header to be 'application/prs.coverage+json' but found {res.headers.get("content-type")}")
+    document=res.json()
+    validator.validate(document)
+    return document
+
+def validate_range(ndarr,axisNames:List[List[str]]=None,axisShape:List[int]=None,catEncodingValues:List[int]=None)->None:
+    if type(ndarr) is str:
+        ndarr=loadStringDocument(ndarr)
+    if axisNames:
+        if ndarr["axisNames"]:
+            custom_validator({
+                    "title":"Member 'axisNames' should match the provided arguments",
+                    "description": "Given a Domain, then the value of member 'axisNames' should match that of the Domain axes",
+                    "type":"array",
+                    "oneOf":list(map(lambda x:{"const":x},axisNames))
+                    }).validate(ndarr["axisNames"])
+    if axisShape:
+        if ndarr["shape"]:
+            custom_validator({
+                "title":"Member 'shape' should match the provided argument",
+                "description":"Given the shape of the Domain, the value of member 'shape' should match the provided argument",
+                "const":axisShape}).validate(ndarr["shape"])
+    if ndarr["type"]=="NdArray":
+        if ndarr["shape"]:
+            custom_validator({
+                    "title":"Product of 'shape' member should equal length of values array",
+                    "description":"Inequivalence of these values indicates missing data",
+                    "const":math.prod(ndarr["shape"])
+                    }).validate(len(ndarr["values"]))
+        if catEncodingValues:
+            custom_validator({
+                    "type":"array",
+                    "items":{
+                        "type":"integer",
+                        "enum":catEncodingValues
+                    }
+                }).validate(ndarr["values"])
+    else:
+        for _,tileSet in enumerate(ndarr["tileSets"]):
+            urlTemplate=URITemplate(tileSet["urlTemplate"])
+            tileShape=tileSet["tileShape"]
+            
+            dimensions=[d for d in tileShape if d is not None]
+            # Build a list for tiled axis
+            tiled_axes=[
+                name for name, shape_val in zip(ndarr["axisNames"],tileShape)
+                if shape_val is not None
+            ]
+            # Create a cartesian product of available indices and for each, fetch the ndArray            
+            cartesianProd=list(product(*[range(d) for d in dimensions]))
+
+            for _,indices in enumerate(cartesianProd):
+                values=dict(zip(tiled_axes, indices))
+                url=urlTemplate.expand(values)
+                validate_range(loadStringDocument(url),axisNames,None,catEncodingValues)
+                
+def validate_parameter(param)->List[int]|None:
+    "Validates the categoryEncoding member"
+    
+    if not "categoryEncoding" in param: 
+        return None
+    
+    if not param["observedProperty"]["category"]:
+        raise jsonschema.ValidationError("observedProperty must have member 'categories' if member 'categoryEncoding' given ")
+    custom_validator({
+        "title":"Each CategoryEncoding must have a Category object",
+        "description":"Given a categoryEncoding, then the keys of the value must have an associated Category object",
+        "type":"array",
+        "items":{
+            "type":"string",
+            "enum":list(map(lambda x: x["id"],parameter["observedProperty"]["categories"]))
+                }
+        }).validate(list(parameter["categoryEncoding"].keys()))
+    catEncodingValues=[]
+    for i in parameter["categoryEncoding"]:
+        catEncoding=parameter["categoryEncoding"][i]
+        if isinstance(cat,list):
+            catEncodingValues+=catEncoding
+        else:
+            catEncodingValues.append(catEncoding)
+    custom_validator({
+        "title":"Uniqueness of categoryEncoding integers",
+        "description":"Given a categoryEncoding, then all described values must be unique",
+        "type":"array",
+        "items":{
+            "type":"integer",
+            "uniqueItems":True
+        }
+    }).validate(catEncodingValues)
+    
+    return catEncodingValues
+   
+def parse_domain(dom)->[List[List[str]],List[int]]:
+    "Generate expected axisNames and axis shape values"
+    axisNamesAndLengths={}
+    for axisName in dom["axes"]:
+        axis=dom["axes"][axisName]
+        if not "dataType" in axis or axis["dataType"] == "primitive":
+            if not "values" in axis:
+                step=(axis["stop"]-axis["start"])/(axis["num"]-1)
+                values=[axis["start"]+i*step for i in range(axis["num"])]
+                axis={"values":values}
+                dom["axes"][axisName]=axis
+            else:
+                values=axis["values"]
+                axisNamesAndLengths[axisName]=len(values)
+                isAscending=values[0]<values[len(values)-1]
+                if isAscending:
+                    valid=all(x<y for x,y in zip(values,values[1:]))
+                else:
+                    valid=all(x>y for x,y in zip(values,values[1:]))
+                custom_validator(schema={
+                    "title":"Monotonicity of primitive axis",
+                    "description":"Given a Primitive axis, then the values must be strictly motonotic (increasing or descreasing)",
+                    "const":True
+                }).validate(valid)
+        axisNamesAndLengths[axisName]=len(axis["values"])
+    return axis_name_combinations(axisNamesAndLengths)
+
+def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None):
+    if type(cov["domain"]) is str:
+        cov["domain"]=loadStringDocument(cov["domain"])
+    
+    if catEncodings is None:
+        catEncodings={}
+    if cov["parameters"]:
+        for i in cov["parameters"]:
+            catEncodings[i]=validate_parameter(cov["parameters"][i])
+            
+    custom_validator({
+        "title":"Each range is described by a Parameter object",
+        "description":"Each range value should have an associated parameter in the Coverage or CoverageCollection",
+        "type":"array",
+        "items":{
+            "type":"string",
+            "enum":list(catEncodings.keys())
+        }}).validate(list(cov["ranges"].keys()))
+    
+    [axisNames,axisShape]=parse_domain(cov["domain"])
+    for i in cov["ranges"]:
+        validate_range(cov["ranges"][i],axisNames,axisShape,catEncodingValues=catEncodings[i])
+    
+
+def validate_coverage_collection(covcoll):
+    catEncodings={}
+    if obj["parameters"]:
+        for i in obj["parameters"]:
+            catEncodings[i]=validate_parameter(obj)
+    for i in obj["coverages"]:
+        validate_coverage(obj["coverages"][i],catEncodings)
+  
+def is_url(ref:str)->bool:
+    "Simple utility to determine if string is an absolute uri"
+    result= urlparse(ref)
+    if not result.scheme:
+        return False
+    if result.scheme == "file":
+        return False
+    return True
 
 if __name__ == "__main__":
-    import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('--source', type=str, choices=['url', 'file'], default='file', help='Source of the CoverageJSON document')
     parser.add_argument('covjson_path', type=str,
-                        help='Path to CoverageJSON document')
+                        help='Location of CoverageJSON document. Pass an absolute URL (include scheme of link) or a relative file path. ')
     
     args = parser.parse_args()
 
-    if args.source == 'url':
-        import requests
-        # Get the file from the URL
+    if is_url(args.covjson_path):
         response = requests.get(args.covjson_path)
         response.raise_for_status()  # Raise an exception if the request was unsuccessful
         obj = response.json()
@@ -63,6 +258,17 @@ if __name__ == "__main__":
         with open(args.covjson_path, encoding="utf-8") as f:
             obj = json.load(f)
 
-    validator = create_custom_validator("/schemas/coveragejson")
     validator.validate(obj)
+    
+    
+    # Do custom validation
+    match obj["type"]:
+        case "NdArray":
+            validate_range(obj)
+        case "TiledNdArray":
+            validate_range(obj)
+        case "Coverage":
+            validate_coverage(obj)
+        case "CoverageCollection":
+            validate_coverage_collection(obj)
     print("Valid!")

--- a/tools/validator.py
+++ b/tools/validator.py
@@ -6,12 +6,12 @@ import os
 import json
 import jsonschema
 import requests
-from typing import Dict,List
+from typing import Dict,List,Tuple
 from uritemplate import URITemplate
 from urllib.parse import urlparse
 import math
 from itertools import product,permutations
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from warnings import warn
 
 def create_schema_store():
@@ -56,27 +56,46 @@ def custom_validator(schema:object):
     "A  validator function to validate against runtime schemas"
     return jsonschema.Draft202012Validator(schema)
 
-def axis_name_combinations(axisData:Dict[str,int])->List[List[str],List[int]]:
-    "Return all possible combinations of the expected shape and axisNames of the range\n"
-    "This is required for domains where multiple axes have the same lengths and so data can be arranged in multiple valid combinations"
+def axis_name_combinations(axis_data:Dict[str,int])->Tuple[List[str],List[int]]:
+    """
+    Returns a tuple of two lists:
+    1. A list of all unique axis name lists (both with and without singletons).
+    2. A list of all unique shape lists (both with and without singletons).
+    """
     
-    groups=defaultdict(list)
-    for axisName,length in axisData.items():
-        groups[length].append(axisName)
-    sortedLengths=sorted(groups.keys())
-    permutations_per_length=[list(permutations(groups[l])) for l in sortedLengths]
-    
-    axisShape=[]
-    for length in sortedLengths:
-        axisShape.extend([length]*len(groups[length]))
+    unique_names_set = set()
+    unique_shapes_set = set()
+
+    # Process both scenarios: [IgnoreSingletons=False, IgnoreSingletons=True]
+    for ignore_singletons in [False, True]:
+        groups = defaultdict(list)
+        for name, length in axis_data.items():
+            if ignore_singletons and length == 1:
+                continue
+            groups[length].append(name)
+
+        # Sort lengths to maintain a predictable base order
+        sorted_lengths = sorted(groups.keys())
+        permutations_per_length = [list(permutations(groups[l])) for l in sorted_lengths]
         
-    axisNames=[]
-    for combo in product(*permutations_per_length):
-        axisNames.append([name for sub in combo for name in sub])
-    return [axisNames,axisShape]       
+        # Generate all combinations via Cartesian product
+        for combo in product(*perms_per_length):
+            # Flatten names and generate matching shape
+            flat_names = [name for sub in combo for name in sub]
+            flat_shape = [axis_data[name] for name in flat_names]
+            
+            # Add to sets as tuples (since lists are not hashable)
+            unique_names_set.add(tuple(flat_names))
+            unique_shapes_set.add(tuple(flat_shape))
+
+    # Convert back to List[List[...]] format
+    axisNames = [list(n) for n in unique_names_set]
+    axisShape = [list(s) for s in unique_shapes_set]
+
+    return axisNames,axisShape
 
 def loadStringDocument(url:str)->Dict:
-    "Loads a URL CoverageJSON Document and validates the request and the json document"
+    "Loads a URL CoverageJSON Document"
     custom_validator({"type":"string","format":"uri"}).validate(url)
     
     res=requests.get(url)
@@ -84,14 +103,19 @@ def loadStringDocument(url:str)->Dict:
     if res.headers.get("content-type") != "application/prs.coverage+json":
         warn(f"Expected content-type header to be 'application/prs.coverage+json' but found {res.headers.get("content-type")}")
     document=res.json()
-    validator.validate(document)
     return document
 
-def validate_range(ndarr,axisNames:List[List[str]]=None,axisShape:List[int]=None,catEncodingValues:List[int]=None)->None:
+def validate_range(ndarr,axisNames:List[List[str]]=None,
+                   axisShape:List[List[int]]=None,
+                   catEncodingValues:List[int]=None,
+                   dataType:str=None
+                   )->None:
     if type(ndarr) is str:
         ndarr=loadStringDocument(ndarr)
+        validator.validate(ndarr)
+        
     if axisNames:
-        if ndarr["axisNames"]:
+        if "axisNames" in ndarr:
             custom_validator({
                     "title":"Member 'axisNames' should match the provided arguments",
                     "description": "Given a Domain, then the value of member 'axisNames' should match that of the Domain axes",
@@ -99,18 +123,21 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,axisShape:List[int]=None
                     "oneOf":list(map(lambda x:{"const":x},axisNames))
                     }).validate(ndarr["axisNames"])
     if axisShape:
-        if ndarr["shape"]:
+        if "shape" in ndarr:
             custom_validator({
                 "title":"Member 'shape' should match the provided argument",
                 "description":"Given the shape of the Domain, the value of member 'shape' should match the provided argument",
-                "const":axisShape}).validate(ndarr["shape"])
+                "type":"array",
+                "oneOf":list(map(lambda x:{"const":x},axisShape))}).validate(ndarr["shape"])
+
     if ndarr["type"]=="NdArray":
-        if ndarr["shape"]:
+        if "shape" in ndarr:
             custom_validator({
                     "title":"Product of 'shape' member should equal length of values array",
                     "description":"Inequivalence of these values indicates missing data",
                     "const":math.prod(ndarr["shape"])
                     }).validate(len(ndarr["values"]))
+        # TODO expect only one value
         if catEncodingValues:
             custom_validator({
                     "type":"array",
@@ -118,7 +145,13 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,axisShape:List[int]=None
                         "type":"integer",
                         "enum":catEncodingValues
                     }
-                }).validate(ndarr["values"])
+                }).validate(list(filter(lambda x:x is not None,ndarr["values"])))
+        if dataType:
+            custom_validator({
+                "title":"DataType of range",
+                "description":"If part of a TiledNdArray, then the dataType of resolved range must be the same as that of parent object",
+                "const":dataType
+            }).validate(ndarr["dataType"])
     else:
         for _,tileSet in enumerate(ndarr["tileSets"]):
             urlTemplate=URITemplate(tileSet["urlTemplate"])
@@ -136,7 +169,7 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,axisShape:List[int]=None
             for _,indices in enumerate(cartesianProd):
                 values=dict(zip(tiled_axes, indices))
                 url=urlTemplate.expand(values)
-                validate_range(loadStringDocument(url),axisNames,None,catEncodingValues)
+                validate_range(loadStringDocument(url),axisNames,None,catEncodingValues,ndarr["dataType"])
                 
 def validate_parameter(param)->List[int]|None:
     "Validates the categoryEncoding member"
@@ -144,7 +177,7 @@ def validate_parameter(param)->List[int]|None:
     if not "categoryEncoding" in param: 
         return None
     
-    if not param["observedProperty"]["category"]:
+    if not "categories" in  param["observedProperty"]:
         raise jsonschema.ValidationError("observedProperty must have member 'categories' if member 'categoryEncoding' given ")
     custom_validator({
         "title":"Each CategoryEncoding must have a Category object",
@@ -152,13 +185,13 @@ def validate_parameter(param)->List[int]|None:
         "type":"array",
         "items":{
             "type":"string",
-            "enum":list(map(lambda x: x["id"],parameter["observedProperty"]["categories"]))
+            "enum":list(map(lambda x: x["id"],param["observedProperty"]["categories"]))
                 }
-        }).validate(list(parameter["categoryEncoding"].keys()))
+        }).validate(list(param["categoryEncoding"].keys()))
     catEncodingValues=[]
-    for i in parameter["categoryEncoding"]:
-        catEncoding=parameter["categoryEncoding"][i]
-        if isinstance(cat,list):
+    for i in param["categoryEncoding"]:
+        catEncoding=param["categoryEncoding"][i]
+        if isinstance(catEncoding,list):
             catEncodingValues+=catEncoding
         else:
             catEncodingValues.append(catEncoding)
@@ -174,8 +207,13 @@ def validate_parameter(param)->List[int]|None:
     
     return catEncodingValues
    
-def parse_domain(dom)->[List[List[str]],List[int]]:
+def validate_domain(dom,domainType:str=None)->[List[List[str]],List[int]]:
     "Generate expected axisNames and axis shape values"
+    
+    if domainType:
+        dom["domainType"]=domainType
+    validator.validate(dom)
+    
     axisNamesAndLengths={}
     for axisName in dom["axes"]:
         axis=dom["axes"][axisName]
@@ -199,15 +237,26 @@ def parse_domain(dom)->[List[List[str]],List[int]]:
                     "const":True
                 }).validate(valid)
         axisNamesAndLengths[axisName]=len(axis["values"])
-    return axis_name_combinations(axisNamesAndLengths)
+        axisData=axis_name_combinations(axisNamesAndLengths)
+    return axisData
 
-def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None):
+def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None,domainType:str=None,referencing:Dict=None):
     if type(cov["domain"]) is str:
         cov["domain"]=loadStringDocument(cov["domain"])
-    
+    if referencing and "referencing" not in cov["domain"]:
+        cov["domain"]["referencing"]=referencing
+
+    if domainType and 'domainType' in cov:
+        custom_validator({
+            "title":"CoverageCollection and Coverage 'domainType' members",
+            "description":"The value of the 'domainType' member in the CoverageCollection and Coverage",
+            "const":domainType
+        }).validate(cov["domainType"])
+            
     if catEncodings is None:
         catEncodings={}
-    if cov["parameters"]:
+        
+    if "parameters" in cov:
         for i in cov["parameters"]:
             catEncodings[i]=validate_parameter(cov["parameters"][i])
             
@@ -220,18 +269,18 @@ def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None):
             "enum":list(catEncodings.keys())
         }}).validate(list(cov["ranges"].keys()))
     
-    [axisNames,axisShape]=parse_domain(cov["domain"])
+    axisNames,axisShape=validate_domain(cov["domain"],domainType)
     for i in cov["ranges"]:
-        validate_range(cov["ranges"][i],axisNames,axisShape,catEncodingValues=catEncodings[i])
+        validate_range(cov["ranges"][i],axisNames,axisShape,catEncodings[i])
     
 
 def validate_coverage_collection(covcoll):
     catEncodings={}
-    if obj["parameters"]:
-        for i in obj["parameters"]:
-            catEncodings[i]=validate_parameter(obj)
-    for i in obj["coverages"]:
-        validate_coverage(obj["coverages"][i],catEncodings)
+    if covcoll["parameters"]:
+        for i in covcoll["parameters"]:
+            catEncodings[i]=validate_parameter(covcoll["parameters"][i])
+    for cov in covcoll["coverages"]:
+        validate_coverage(cov,catEncodings,covcoll["domainType"],referencing=covcoll["referencing"] if covcoll["referencing"] is not None else None)
   
 def is_url(ref:str)->bool:
     "Simple utility to determine if string is an absolute uri"
@@ -241,6 +290,21 @@ def is_url(ref:str)->bool:
     if result.scheme == "file":
         return False
     return True
+
+def runtime_validator(obj):
+    match obj["type"]:
+        case "NdArray":
+            validate_range(obj)
+        case "TiledNdArray":
+            validate_range(obj)
+        case "Coverage":
+            validate_coverage(obj)
+        case "CoverageCollection":
+            validate_coverage_collection(obj)
+        case "Domain":
+            validate_domain(obj)
+        case _:
+            raise ValueError("Not a CoverageJSON document")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -259,16 +323,5 @@ if __name__ == "__main__":
             obj = json.load(f)
 
     validator.validate(obj)
-    
-    
-    # Do custom validation
-    match obj["type"]:
-        case "NdArray":
-            validate_range(obj)
-        case "TiledNdArray":
-            validate_range(obj)
-        case "Coverage":
-            validate_coverage(obj)
-        case "CoverageCollection":
-            validate_coverage_collection(obj)
+    runtime_validator(obj)
     print("Valid!")

--- a/tools/validator.py
+++ b/tools/validator.py
@@ -116,7 +116,13 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,
     if type(ndarr) is str:
         ndarr=loadStringDocument(ndarr)
         validator.validate(ndarr)
-        
+    
+    if "shape" in ndarr and "axisNames" in ndarr:
+        custom_validator({
+            "description":"Provided shape and axisNames in ndarray, their lengths should be equivalent",
+            "const":len(ndarr["shape"])
+        }).validate(len(ndarr["axisNames"]))
+       
     if axisNames:
         if "axisNames" in ndarr:
             custom_validator({
@@ -132,7 +138,6 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,
                 "description":"Given the shape of the Domain, the value of member 'shape' should match the provided argument",
                 "type":"array",
                 "oneOf":list(map(lambda x:{"const":x},axisShape))}).validate(ndarr["shape"])
-
     if ndarr["type"]=="NdArray":
         if "shape" in ndarr:
             custom_validator({
@@ -140,7 +145,6 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,
                     "description":"Inequivalence of these values indicates missing data",
                     "const":math.prod(ndarr["shape"])
                     }).validate(len(ndarr["values"]))
-        # TODO expect only one value
         if catEncodingValues:
             custom_validator({
                     "type":"array",
@@ -158,14 +162,31 @@ def validate_range(ndarr,axisNames:List[List[str]]=None,
     else:
         for _,tileSet in enumerate(ndarr["tileSets"]):
             urlTemplate=URITemplate(tileSet["urlTemplate"])
+            
             tileShape=tileSet["tileShape"]
             
+            custom_validator({
+                "title":"tileShape has same length as shape",
+                "const":len(ndarr["shape"]) 
+            }).validate(len(tileShape))
             dimensions=[d for d in tileShape if d is not None]
             # Build a list for tiled axis
             tiled_axes=[
                 name for name, shape_val in zip(ndarr["axisNames"],tileShape)
                 if shape_val is not None
             ]
+            
+            # Simple validation of the urlTemplate
+            custom_validator({
+                "title":"urlTemplate variables validation",
+                "description":"urlTemplate variables only includes tiled axisNames",
+                "type":"array",
+                "items":{
+                    "enum":tiled_axes
+                }
+            }).validate(list(urlTemplate.variable_names))
+            
+            
             # Create a cartesian product of available indices and for each, fetch the ndArray            
             cartesianProd=list(product(*[range(d) for d in dimensions]))
 
@@ -191,25 +212,38 @@ def validate_parameter(param)->List[int]|None:
             "enum":list(map(lambda x: x["id"],param["observedProperty"]["categories"]))
                 }
         }).validate(list(param["categoryEncoding"].keys()))
+    
     catEncodingValues=[]
     for i in param["categoryEncoding"]:
         catEncoding=param["categoryEncoding"][i]
         if isinstance(catEncoding,list):
-            catEncodingValues+=catEncoding
+            catEncodingValues.extend(catEncoding)
         else:
             catEncodingValues.append(catEncoding)
+            
     custom_validator({
         "title":"Uniqueness of categoryEncoding integers",
         "description":"Given a categoryEncoding, then all described values must be unique",
         "type":"array",
+        "uniqueItems":True,
         "items":{
-            "type":"integer",
-            "uniqueItems":True
+            "type":"integer"
         }
     }).validate(catEncodingValues)
-    
     return catEncodingValues
-   
+
+def validate_parameter_group(p_group:Dict,paramKeys:List[str]):
+    "Validate parameterGroup members"
+    custom_validator({
+        "title":"ParameterGroup validation",
+        "description":"Given a ParameterGroup object, the values of the 'members' key must be existing parameters keys",
+        "type":"array",
+        "items":{
+            "type":"string",
+            "enum":paramKeys
+        }
+    }).validate(p_group["members"])
+    
 def validate_domain(dom,domainType:str=None)->[List[List[str]],List[int]]:
     "Generate expected axisNames and axis shape values"
     
@@ -246,9 +280,18 @@ def validate_domain(dom,domainType:str=None)->[List[List[str]],List[int]]:
 def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None,domainType:str=None,referencing:Dict=None):
     if type(cov["domain"]) is str:
         cov["domain"]=loadStringDocument(cov["domain"])
-    if referencing and "referencing" not in cov["domain"]:
-        cov["domain"]["referencing"]=referencing
-
+        
+    if catEncodings is None:
+        catEncodings={}
+        
+    if "parameters" in cov:
+        for i in cov["parameters"]:
+            catEncodings[i]=validate_parameter(cov["parameters"][i])
+    
+    if "parameterGroups" in cov:
+        for p_group in cov["parameterGroups"]:
+            validate_parameter_group(p_group,list(catEncodings.keys()))
+    
     if domainType and 'domainType' in cov:
         custom_validator({
             "title":"CoverageCollection and Coverage 'domainType' members",
@@ -256,13 +299,10 @@ def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None,domainType:str=N
             "const":domainType
         }).validate(cov["domainType"])
             
-    if catEncodings is None:
-        catEncodings={}
+    
+    if referencing and "referencing" not in cov["domain"]:
+        cov["domain"]["referencing"]=referencing
         
-    if "parameters" in cov:
-        for i in cov["parameters"]:
-            catEncodings[i]=validate_parameter(cov["parameters"][i])
-            
     custom_validator({
         "title":"Each range is described by a Parameter object",
         "description":"Each range value should have an associated parameter in the Coverage or CoverageCollection",
@@ -279,9 +319,14 @@ def validate_coverage(cov,catEncodings:Dict[str,List[int]]=None,domainType:str=N
 
 def validate_coverage_collection(covcoll):
     catEncodings={}
-    if covcoll["parameters"]:
+    if "parameters" in covcoll:
         for i in covcoll["parameters"]:
             catEncodings[i]=validate_parameter(covcoll["parameters"][i])
+            
+    if "parameterGroups" in covcoll:
+        for p_group in covcoll["parameterGroups"]:
+            validate_parameter_group(p_group,list(catEncodings.keys()))
+            
     for cov in covcoll["coverages"]:
         validate_coverage(cov,catEncodings,covcoll["domainType"],referencing=covcoll["referencing"] if covcoll["referencing"] is not None else None)
   
@@ -295,6 +340,7 @@ def is_url(ref:str)->bool:
     return True
 
 def runtime_validator(obj):
+    validator.validate(obj)
     match obj["type"]:
         case "NdArray":
             validate_range(obj)
@@ -306,8 +352,6 @@ def runtime_validator(obj):
             validate_coverage_collection(obj)
         case "Domain":
             validate_domain(obj)
-        case _:
-            raise ValueError("Not a CoverageJSON document")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -325,6 +369,5 @@ if __name__ == "__main__":
         with open(args.covjson_path, encoding="utf-8") as f:
             obj = json.load(f)
 
-    validator.validate(obj)
     runtime_validator(obj)
     print("Valid!")


### PR DESCRIPTION
1. Arguments: No need to specify that document is a URL via the `source=url` flag. Remember to use absolute URLs with scheme
2. `NdArray`: `axisNames`,`shape`, `tileShape` contains valid lengths and arrangement. Does not check for edge tiles though. Ranges also reference existing parameters
3. Validate that the `dataType` and `axisNames` from a loaded TileSet are the same as those of parent TiledNdArray
4. `categoryEncoding`: If specified, then the member `categories` is expected in the `observedProperty`
5. `TiledNdArray`: Validate that `urlTemplate` is valid (variables are of tiled axisNames).
6. `media type`: If an URL is passed, then expect the response to have the correct content-type header. If it is `application/prs.coverage+json`, warn of the deprecation, else warn of the incorrect header value
7. `categoryEncoding`: If specified, values of categories are unique. Because of the approach, expect that values of ranges are integers
8. `categoryEncoding`: If specified, then the values of the NdArray's should only include those in categoryEncoding
9. Add tests to validate the runtime_validator
10. Add sanity checks for the runtime_validator
11. `ParameterGroup`: elements of `members` reference existing parameters

This MR partially addresses #https://github.com/opengeospatial/CoverageJSON/issues/179
This validation approach fetches all variations of a TiledNdArray and recursively tests resulting ranges thus increasing validation time